### PR TITLE
Resolving bug in ORM with regards to plugin use

### DIFF
--- a/lib/ORM.js
+++ b/lib/ORM.js
@@ -191,7 +191,8 @@ ORM.prototype.use = function (plugin_const, opts) {
 		}
 	}
 
-	var plugin = new plugin_const(this, opts || {});
+	// var plugin = new plugin_const(this, opts || {});
+	var plugin = plugin_const(this, opts || {});
 
 	if (typeof plugin.define === "function") {
 		for (var k in this.models) {


### PR DESCRIPTION
During an ES6 conversion on ScoutGroup/fdc_common, I discovered a bug with how we use plugins, instead of using an instance being passed to the .use() method, we instantiate a new instance within the library. This used to work under coffeescript with the older version of JS it transpiled to, but no longer with the ES6 conversion. 

I've left the old line, but removing new (as the code being passed to .use() didn't have a constructor) 
resolved the issue.